### PR TITLE
Add arrow navigation to SlashMenu

### DIFF
--- a/demo/assets/css/style.css
+++ b/demo/assets/css/style.css
@@ -21,3 +21,7 @@
 ::part(button) {
     width: 100%;
 }
+
+[part="button"].selected {
+    background-color: lightblue;
+}

--- a/src/components/base/overlay.ts
+++ b/src/components/base/overlay.ts
@@ -1,0 +1,20 @@
+import { OverlayManager } from "../../core/overlay-manager.ts";
+import { Component } from "../component.ts";
+
+// deno-lint-ignore no-explicit-any
+export abstract class Overlay<P = any, S = any> extends Component<P, S> {
+
+    zIndex: number = 1000;
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+
+        this.style.zIndex = this.zIndex.toString();
+        OverlayManager.instance().push(this);
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        OverlayManager.instance().pop();
+    }
+}

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -15,19 +15,6 @@ export abstract class Component<P = any, S = any> extends HTMLElement {
 
     constructor() {
         super();
-        const proto = Object.getPrototypeOf(this);
-
-        if (proto.connectedCallback !== Component.prototype.connectedCallback) {
-            console.warn(
-                `${this.constructor.name} overrides 'connectedCallback'. Prefer using 'onMount()' instead.`
-            );
-        }
-
-        if (proto.disconnectedCallback !== Component.prototype.disconnectedCallback) {
-            console.warn(
-                `${this.constructor.name} overrides 'disconnectedCallback'. Prefer using 'onUnmount()' instead.`
-            );
-        }
     }
 
     connectedCallback() {

--- a/src/core/overlay-manager.ts
+++ b/src/core/overlay-manager.ts
@@ -1,0 +1,39 @@
+import { EventTypes } from "../utils/event-types.ts";
+import { KeyboardKeys } from "../utils/keyboard-keys .ts";
+
+export class OverlayManager {
+
+    private stack: HTMLElement[] = [];
+
+    private static _instance: null | OverlayManager = null;
+
+    private constructor() {
+        document.addEventListener(EventTypes.KeyDown, (e) => this.handleKey(e));
+    }
+
+    public push(element: HTMLElement) {
+        this.stack.push(element);
+    }
+
+    public pop() {
+        const element = this.stack.pop();
+
+        if (element) {
+            element.remove();
+        }
+    }
+
+    static instance(): OverlayManager {
+        if (this._instance == null) {
+            this._instance = new OverlayManager();
+        }
+
+        return this._instance;
+    }
+
+    private readonly handleKey = (e: KeyboardEvent) => {
+        if (e.key === KeyboardKeys.Escape) {
+            this.pop();
+        }
+    };
+}

--- a/src/plugins/slash-menu/components/slash-menu-item.tsx
+++ b/src/plugins/slash-menu/components/slash-menu-item.tsx
@@ -5,10 +5,12 @@ import { Component } from "../../../components/component.ts";
 export interface SlashMenuItemProps {
     label: string;
     onSelect: () => void;
+    selected?: boolean;
 }
 
 export class SlashMenuItem extends Component<SlashMenuItemProps> {
     render() {
-        return <button parte="button" onClick={this.props.onSelect}>{this.props.label}</button>;
+        const className = this.props.selected ? "selected" : "";
+        return <button part="button" class={className} onClick={this.props.onSelect}>{this.props.label}</button>;
     }
 }

--- a/src/plugins/slash-menu/components/slash-menu.tsx
+++ b/src/plugins/slash-menu/components/slash-menu.tsx
@@ -12,6 +12,7 @@ interface SlashMenuProps {
 interface SlashMenuState {
     items: SlashMenuItemData[];
     showSlashMenu: boolean;
+    selectedIndex: number;
 }
 
 export interface SlashMenuItemData {
@@ -41,7 +42,8 @@ export class SlashMenu extends Component<SlashMenuProps, SlashMenuState> {
                     }
                 }
             ],
-            showSlashMenu: false
+            showSlashMenu: false,
+            selectedIndex: 0
         };
 
         this.contentElement = document.getElementById("content")!;
@@ -64,11 +66,38 @@ export class SlashMenu extends Component<SlashMenuProps, SlashMenuState> {
 
     private readonly handleKey = (e: KeyboardEvent) => {
         if (e.key === "/" && !this.state.showSlashMenu) {
-            this.setState({ showSlashMenu: true });
+            this.setState({ showSlashMenu: true, selectedIndex: 0 });
+            return;
         }
 
-        if (e.key === "Escape" && this.state.showSlashMenu) {
-            this.setState({ showSlashMenu: false });
+        if (!this.state.showSlashMenu) {
+            return;
+        }
+
+        switch (e.key) {
+            case "Escape":
+                this.setState({ showSlashMenu: false });
+                break;
+            case "ArrowDown":
+                e.preventDefault();
+                this.setState({
+                    selectedIndex: (this.state.selectedIndex + 1) % this.state.items.length,
+                });
+                break;
+            case "ArrowUp":
+                e.preventDefault();
+                this.setState({
+                    selectedIndex: (this.state.selectedIndex - 1 + this.state.items.length) % this.state.items.length,
+                });
+                break;
+            case "Enter":
+                e.preventDefault();
+                const item = this.state.items[this.state.selectedIndex];
+                if (item) {
+                    item.onSelect();
+                    this.setState({ showSlashMenu: false });
+                }
+                break;
         }
     };
 
@@ -82,11 +111,12 @@ export class SlashMenu extends Component<SlashMenuProps, SlashMenuState> {
             <Fragment>
                 {this.state.showSlashMenu &&
                     <ul part="menu" class="slash-menu">
-                        {this.state.items.map((item) => (
+                        {this.state.items.map((item, index) => (
                             <li part="item">
                                 <SlashMenuItem
                                     label={item.label}
                                     onSelect={() => item.onSelect()}
+                                    selected={index === this.state.selectedIndex}
                                 />
                             </li>
                         ))}

--- a/src/plugins/slash-menu/components/slash-menu.tsx
+++ b/src/plugins/slash-menu/components/slash-menu.tsx
@@ -1,8 +1,8 @@
 /** @jsx h */
 import { Fragment, h } from "../../../jsx.ts";
-import { Component } from "../../../components/component.ts";
 import { SlashMenuItem } from "./slash-menu-item.tsx";
 import { SlashMenuPluginExtension } from "../slash-menu-plugin.tsx";
+import { Overlay } from "../../../components/base/overlay.ts";
 
 
 interface SlashMenuProps {
@@ -11,7 +11,6 @@ interface SlashMenuProps {
 
 interface SlashMenuState {
     items: SlashMenuItemData[];
-    showSlashMenu: boolean;
     selectedIndex: number;
 }
 
@@ -20,9 +19,10 @@ export interface SlashMenuItemData {
     onSelect: () => void;
 }
 
-export class SlashMenu extends Component<SlashMenuProps, SlashMenuState> {
-    
+export class SlashMenu extends Overlay<SlashMenuProps, SlashMenuState> {
+
     contentElement: HTMLElement;
+
 
     constructor() {
         super();
@@ -42,7 +42,6 @@ export class SlashMenu extends Component<SlashMenuProps, SlashMenuState> {
                     }
                 }
             ],
-            showSlashMenu: false,
             selectedIndex: 0
         };
 
@@ -65,40 +64,37 @@ export class SlashMenu extends Component<SlashMenuProps, SlashMenuState> {
     }
 
     private readonly handleKey = (e: KeyboardEvent) => {
-        if (e.key === "/" && !this.state.showSlashMenu) {
-            this.setState({ showSlashMenu: true, selectedIndex: 0 });
-            return;
-        }
 
-        if (!this.state.showSlashMenu) {
-            return;
-        }
 
-        switch (e.key) {
-            case "Escape":
-                this.setState({ showSlashMenu: false });
-                break;
-            case "ArrowDown":
-                e.preventDefault();
-                this.setState({
-                    selectedIndex: (this.state.selectedIndex + 1) % this.state.items.length,
-                });
-                break;
-            case "ArrowUp":
-                e.preventDefault();
-                this.setState({
-                    selectedIndex: (this.state.selectedIndex - 1 + this.state.items.length) % this.state.items.length,
-                });
-                break;
-            case "Enter":
-                e.preventDefault();
-                const item = this.state.items[this.state.selectedIndex];
-                if (item) {
-                    item.onSelect();
-                    this.setState({ showSlashMenu: false });
-                }
-                break;
-        }
+        // if (!this.state.showSlashMenu) {
+        //     return;
+        // }
+
+        // switch (e.key) {
+        //     // case "Escape":
+        //     //     this.setState({ showSlashMenu: false });
+        //     //     break;
+        //     case "ArrowDown":
+        //         e.preventDefault();
+        //         this.setState({
+        //             selectedIndex: (this.state.selectedIndex + 1) % this.state.items.length,
+        //         });
+        //         break;
+        //     case "ArrowUp":
+        //         e.preventDefault();
+        //         this.setState({
+        //             selectedIndex: (this.state.selectedIndex - 1 + this.state.items.length) % this.state.items.length,
+        //         });
+        //         break;
+        //     case "Enter":
+        //         e.preventDefault();
+        //         const item = this.state.items[this.state.selectedIndex];
+        //         if (item) {
+        //             item.onSelect();
+        //             this.setState({ showSlashMenu: false });
+        //         }
+        //         break;
+        // }
     };
 
     insert(content: string) {
@@ -109,18 +105,17 @@ export class SlashMenu extends Component<SlashMenuProps, SlashMenuState> {
     render() {
         return (
             <Fragment>
-                {this.state.showSlashMenu &&
-                    <ul part="menu" class="slash-menu">
-                        {this.state.items.map((item, index) => (
-                            <li part="item">
-                                <SlashMenuItem
-                                    label={item.label}
-                                    onSelect={() => item.onSelect()}
-                                    selected={index === this.state.selectedIndex}
-                                />
-                            </li>
-                        ))}
-                    </ul>}
+                <ul part="menu" class="slash-menu">
+                    {this.state.items.map((item, index) => (
+                        <li part="item">
+                            <SlashMenuItem
+                                label={item.label}
+                                onSelect={() => item.onSelect()}
+                                selected={index === this.state.selectedIndex}
+                            />
+                        </li>
+                    ))}
+                </ul>
             </Fragment>
         );
     }

--- a/src/plugins/slash-menu/slash-menu-plugin.tsx
+++ b/src/plugins/slash-menu/slash-menu-plugin.tsx
@@ -28,9 +28,16 @@ export class SlashMenuPlugin extends Plugin {
 
         const extensionPlugins = plugins.filter(isSlashMenuPluginExtension);
 
-        root.append(
-            <SlashMenu extensionPlugins={extensionPlugins} />
-        );
+        document.addEventListener("keydown", (e) => this.handleKey(e, root, extensionPlugins))
+
+    }
+
+    private readonly handleKey = (e: KeyboardEvent, root: HTMLElement, extensionPlugins: (Plugin & SlashMenuPluginExtension)[]) => {
+        if (e.key === "/") {
+            root.append(
+                <SlashMenu extensionPlugins={extensionPlugins} />
+            );
+        }
     }
 }
 

--- a/src/utils/event-types.ts
+++ b/src/utils/event-types.ts
@@ -1,0 +1,22 @@
+export class EventTypes {
+    static readonly KeyDown = 'keydown';
+    static readonly KeyUp = 'keyup';
+    static readonly KeyPress = 'keypress';
+    static readonly MouseDown = 'mousedown';
+    static readonly MouseUp = 'mouseup';
+    static readonly MouseMove = 'mousemove';
+    static readonly Click = 'click';
+    static readonly DblClick = 'dblclick';
+    static readonly ContextMenu = 'contextmenu';
+    static readonly Focus = 'focus';
+    static readonly Blur = 'blur';
+    static readonly Change = 'change';
+    static readonly Input = 'input';
+    static readonly Submit = 'submit';
+    static readonly Scroll = 'scroll';
+    static readonly Resize = 'resize';
+    static readonly Drag = 'drag';
+    static readonly Drop = 'drop';
+    static readonly DragStart = 'dragstart';
+    static readonly DragEnd = 'dragend';
+}

--- a/src/utils/keyboard-keys .ts
+++ b/src/utils/keyboard-keys .ts
@@ -1,0 +1,19 @@
+export class KeyboardKeys {
+    static readonly Escape = 'Escape';
+    static readonly Enter = 'Enter';
+    static readonly Tab = 'Tab';
+    static readonly Space = ' ';
+    static readonly ArrowUp = 'ArrowUp';
+    static readonly ArrowDown = 'ArrowDown';
+    static readonly ArrowLeft = 'ArrowLeft';
+    static readonly ArrowRight = 'ArrowRight';
+    static readonly Backspace = 'Backspace';
+    static readonly Delete = 'Delete';
+    static readonly Slash = '/';
+    static readonly Period = '.';
+    static readonly Comma = ',';
+    static readonly Shift = 'Shift';
+    static readonly Control = 'Control';
+    static readonly Alt = 'Alt';
+    static readonly Meta = 'Meta';
+}


### PR DESCRIPTION
## Summary
- support keyboard navigation for SlashMenu items
- highlight selected menu item in demo styles

## Testing
- `deno task test` *(fails: `deno: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b010e6bc48332bcd90bf51d0df091